### PR TITLE
Fixed numbering in Quiz in PHP file

### DIFF
--- a/src/lab/Experiments.html
+++ b/src/lab/Experiments.html
@@ -88,7 +88,7 @@
 			
 			<!-- =================================================================================================================================== -->
 			<div class="container-fluid"  style="margin-left: 35px; margin-right: 35px;">
-				<h2 class="text-h2-lightblue" style=" margin-bottom: 20px; margin-top: 10px; "><a href="http://vlabs.ac.in/chemical-sciences-labs.html" class="sidebar-a" > Chemical Sciences</a><br/></h2>
+				<h2 class="text-h2-lightblue" style=" margin-bottom: 20px; margin-top: 10px; "><a href="http://mas-iiith.vlabs.ac.in/" class="sidebar-a" > Chemical Sciences</a><br/></h2>
 					
 					<div class="row">
 						<div class="col-md-2 sidebar-col-2">

--- a/src/lab/Introduction.html
+++ b/src/lab/Introduction.html
@@ -88,7 +88,7 @@
 			
 			<!-- =================================================================================================================================== -->
 			<div class="container-fluid"  style="margin-left: 35px; margin-right: 35px;">
-				<h2 class="text-h2-lightblue" style=" margin-bottom: 20px; margin-top: 10px; "><a href="http://vlabs.ac.in/chemical-sciences-labs.html" class="sidebar-a" > Chemical Sciences</a><br/></h2>
+				<h2 class="text-h2-lightblue" style=" margin-bottom: 20px; margin-top: 10px; "><a href="http://mas-iiith.vlabs.ac.in/" class="sidebar-a" > Chemical Sciences</a><br/></h2>
 					
 					<div class="row">
 						<div class="col-md-2 sidebar-col-2">

--- a/src/lab/List of experiments.html
+++ b/src/lab/List of experiments.html
@@ -88,7 +88,7 @@
 			
 			<!-- =================================================================================================================================== -->
 			<div class="container-fluid"  style="margin-left: 35px; margin-right: 35px;">
-				<h2 class="text-h2-lightblue" style=" margin-bottom: 20px; margin-top: 10px; "><a href="http://vlabs.ac.in/chemical-sciences-labs.html" class="sidebar-a" > Chemical Sciences</a><br/></h2>
+				<h2 class="text-h2-lightblue" style=" margin-bottom: 20px; margin-top: 10px; "><a href="http://mas-iiith.vlabs.ac.in/" class="sidebar-a" > Chemical Sciences</a><br/></h2>
 					
 					<div class="row">
 						<div class="col-md-2 sidebar-col-2">

--- a/src/lab/exp1/quiz.php
+++ b/src/lab/exp1/quiz.php
@@ -66,8 +66,6 @@ function getOptions(opt){
 
   <form name="quiz" action="quiz.php" method="POST">
   <ol>
-  <table>
-  <tr><td width=70%>
     <li>
 	     The magnitude of the harmonic force increases linearly with the internuclear separation of a diatomic molecule 
       <ol type="True">
@@ -87,8 +85,6 @@ function getOptions(opt){
 		}
 	}
 	?>
-  </td></tr>
-  <tr><td>
     <li>
 	 The curvature of the internuclear potential energy is related to the spring constant
       <ol type="True">
@@ -108,9 +104,6 @@ function getOptions(opt){
 		}
 	}
 	?>
-  </td></tr>
-
-  <tr><td>
      <li>
 	 The potential energy at large separation's is essentially the bond energy
       <ol type="True">
@@ -130,9 +123,6 @@ function getOptions(opt){
 		}
 	}
 	?>
-  </td></tr>
-
-  <tr><td>
     <li>
 	      Force is equal to the negative gradient of potential energy
       <ol type="True">
@@ -152,9 +142,6 @@ function getOptions(opt){
 		}
 	}
 	?>
-  </td></tr>
-
-  <tr><td>
      <li>
 	 Morse potential is a symmetric function of internuclear separation 
       <ol type="False">
@@ -174,11 +161,6 @@ function getOptions(opt){
 		}
 	}
 	?>
-  </td></tr>
-
-  
-   
-</table>
   </ol>
 	
 	<?php	if(!$_POST){ ?>


### PR DESCRIPTION
Fixed the numbering in Exp 1 quiz by removing the erroneous <table>, <tr> tags etc and replaced them with <ol>, <li> tags only - puts the numbers in place.

Fixes #160 (it is browser related issue) 